### PR TITLE
Use el.parentNode.removeChild(el) instead of el.remove() for IE < 11

### DIFF
--- a/js/VPAIDHTML5Client.js
+++ b/js/VPAIDHTML5Client.js
@@ -165,8 +165,8 @@ VPAIDHTML5Client.prototype.getID = function () {
  */
 function $removeEl(key) {
     var el = this[key];
-    if (el) {
-        el.remove();
+    if (el && el.parentNode) {
+        el.parentNode.removeChild(el);
         delete this[key];
     }
 }


### PR DESCRIPTION
From [issue 20](https://github.com/MailOnline/VPAIDHTML5Client/issues/20).

Please merge this patch if you feel happy. Thanks much.